### PR TITLE
Added force insert option when importing from array or object

### DIFF
--- a/LFSCoreData/NSManagedObject+Mapping.h
+++ b/LFSCoreData/NSManagedObject+Mapping.h
@@ -60,7 +60,7 @@
  */
 
 + (id)importObject:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context;
-
++ (id)importObject:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context forceInsert:(BOOL)forceInsert;
 /**
  Import objects from an array. See `importObject:inContext:` to see more details.
  
@@ -69,6 +69,7 @@
  
  */
 + (NSArray *)importFromArray:(NSArray *)objects inContext:(NSManagedObjectContext *)context;
++ (NSArray *)importFromArray:(NSArray *)objects inContext:(NSManagedObjectContext *)context forceInsert:(BOOL)forceInsert;
 
 
 /**

--- a/LFSCoreData/NSManagedObject+Mapping.m
+++ b/LFSCoreData/NSManagedObject+Mapping.m
@@ -123,14 +123,14 @@
         } else if ([self isFullSingleRelationshipWithDictionary:dictionary andRelationshipName:relationship]) {
             NSDictionary *relationshipDictionary = [dictionary objectForKey:relationship];;
             if (relationshipDictionary){
-                relationObject = [[self class] importObject:relationshipDictionary inContext:moc inObject:nil mapRelationships:YES forEntityName:entityName];
+                relationObject = [[self class] importObject:relationshipDictionary inContext:moc inObject:nil mapRelationships:YES forEntityName:entityName forceInsert:NO];
             }
             
         } else if ([self isFullMultipleRelationshipWithDictinary:dictionary andRelationshipName:relationship]) {
             relationshipArrayOfDictionaries = [dictionary objectForKey:relationship];
             for (NSDictionary *relationshipDictionary in relationshipArrayOfDictionaries) {
                 if (relationshipDictionary){
-                    id relationSingleObject = [[self class] importObject:relationshipDictionary inContext:moc inObject:nil mapRelationships:YES forEntityName:entityName];
+                    id relationSingleObject = [[self class] importObject:relationshipDictionary inContext:moc inObject:nil mapRelationships:YES forEntityName:entityName forceInsert:NO];
                     NSMutableSet *relationshipset = [NSMutableSet setWithSet:[self valueForKey:relationship]];
                     [relationshipset addObject:relationSingleObject];
                     relationObject = [NSSet setWithSet:relationshipset];
@@ -272,15 +272,18 @@
     return [moc executeFetchRequest:fetchRequest error:nil];
 }
 
-+ (id)importObject:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context
++ (id)importObject:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context{
+    return [self importObject:attributes inContext:context forceInsert:NO];
+}
++ (id)importObject:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context forceInsert:(BOOL)forceInsert
 {
-    return [self importObject:attributes inContext:context inObject:nil];
+    return [self importObject:attributes inContext:context inObject:nil forceInsert:forceInsert];
 }
 
-+ (id) importObject:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context inObject:(id)objectInDatabase
++ (id) importObject:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context inObject:(id)objectInDatabase forceInsert:(BOOL)forceInsert
 {
     NSString *entityName = NSStringFromClass(self);
-    return [self importObject:attributes inContext:context inObject:objectInDatabase mapRelationships:YES forEntityName:entityName];
+    return [self importObject:attributes inContext:context inObject:objectInDatabase mapRelationships:YES forEntityName:entityName forceInsert:forceInsert];
 }
 
 + (id) importObject:(NSDictionary *)attributes
@@ -288,6 +291,7 @@
            inObject:(id)objectInDatabase
    mapRelationships:(BOOL)mapRelationships
       forEntityName:(NSString *)entityName
+        forceInsert:(BOOL)forceInsert
 {
     NSString* idString = [self idStringForEntityName:entityName
                                            inContext:context];
@@ -295,14 +299,18 @@
     id object;
     // TODO: Check if ID is the correct way to get the object.
     
-    if (!objectInDatabase){
-        object = [NSManagedObject objectForIdentifier:attributes[idString] inManagedObjectContext:context forEntityName:entityName];
-        
-        if (!object){
-            object = [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:context];
-        }
+    if (forceInsert){
+        object = [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:context];
     } else {
-        object = objectInDatabase;
+        if (!objectInDatabase){
+            object = [NSManagedObject objectForIdentifier:attributes[idString] inManagedObjectContext:context forEntityName:entityName];
+            
+            if (!object){
+                object = [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:context];
+            }
+        } else {
+            object = objectInDatabase;
+        }
     }
     
     [object mapAttributtes:attributes inContext:context forEntityName:entityName];
@@ -310,51 +318,16 @@
     
     return object;
 }
++ (NSArray *)importFromArray:(NSArray *)objects inContext:(NSManagedObjectContext *)context{
+    return [self importFromArray:objects inContext:context forceInsert:NO];
+}
 
-+ (NSArray *)importFromArray:(NSArray *)objects inContext:(NSManagedObjectContext *)context
++ (NSArray *)importFromArray:(NSArray *)objects inContext:(NSManagedObjectContext *)context forceInsert:(BOOL)forceInsert
 {
-//    NSString* idString = [self idStringForEntityName:entityName
-//                                           inContext:context];
-    
     NSMutableArray *results = [[NSMutableArray alloc] init];
     
-//    NSArray *ids = [objects valueForKey:idString];
-    
-//    NSArray *objectsInDatabase;
-//    NSMutableArray *idsInStrings = nil;
-//    
-//    
-//    if ([ids count] > 0 && [[ids objectAtIndex:0] isKindOfClass:[NSString class]]){
-//        
-//        idsInStrings = [[NSMutableArray alloc] init];
-//        
-//        for (id identifier in ids) {
-//            [idsInStrings addObject:[identifier description]];
-//        }
-//        
-//        objectsInDatabase = [self objectsForIdentifiers:idsInStrings inContext:context];
-//        
-//    } else {
-//        objectsInDatabase = [self objectsForIdentifiers:ids inContext:context];
-//    }
-    
     for (NSDictionary *object in objects) {
-//        id objectInDatabase;
-//        
-//        NSArray *objectArray;
-//        if (idsInStrings){
-//            objectArray = [objectsInDatabase filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(SELF.%@ == %@)",[self identifierForEntityName:[self entityName]] ,[object[@"id"]description]]];
-//        } else {
-//            objectArray = [objectsInDatabase filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(SELF.%@ == %@)",[self identifierForEntityName:[self entityName]] ,object[@"id"]]];
-//        }
-//        
-//        if (objectArray.count > 0){
-//            objectInDatabase = objectArray[0];
-//        } else {
-//            objectInDatabase = [NSEntityDescription insertNewObjectForEntityForName:[self entityName] inManagedObjectContext:context];
-//        }
-//        
-        [results addObject:[self importObject:object inContext:context]];
+        [results addObject:[self importObject:object inContext:context forceInsert:(BOOL)forceInsert]];
     }
     
     return results;

--- a/Test/LFSCoreData Tests.xcodeproj/xcshareddata/xcschemes/Test.xcscheme
+++ b/Test/LFSCoreData Tests.xcodeproj/xcshareddata/xcschemes/Test.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6405C84A852343058B658BB3"
+               BlueprintIdentifier = "50CB621120EF4F5DBE12A689"
                BuildableName = "libPods.a"
                BlueprintName = "Pods"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "35C33D6D295D40ED991FA75C"
+               BlueprintIdentifier = "34BF7FC1AABD45859210404F"
                BuildableName = "libPods-Tests.a"
                BlueprintName = "Pods-Tests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">


### PR DESCRIPTION
`forceInsert:YES` will insert the object without checking if it's on the database first. This way we can do a lot faster imports when we know the database is empty.

Example:

```
NSArray *myArrayOfDictionaries = jsonFileParsingHere...;
[MyObject importFromArray:myArrayOfDictionaries inContext:[[LFSDataModel sharedModel] mainContext] forceInsert:YES];
```
